### PR TITLE
List sources for most pbr projects.

### DIFF
--- a/dowsing/check_source_mapping.py
+++ b/dowsing/check_source_mapping.py
@@ -70,7 +70,9 @@ async def main(packages: List[str]) -> None:
             )
             md_blob = "".join(sorted(f"{f}\n" for f in metadata.source_mapping.keys()))
 
-            if md_blob == wheel_blob:
+            if metadata.source_mapping == {}:
+                print(f"{package_name}: empty dict")
+            elif md_blob == wheel_blob:
                 print(f"{package_name}: ok")
             elif md_blob in ("", "?.py\n"):
                 print(f"{package_name}: COMPLETELY MISSING")

--- a/dowsing/setuptools/__init__.py
+++ b/dowsing/setuptools/__init__.py
@@ -43,6 +43,20 @@ class SetuptoolsReader(BaseReader):
                 if getattr(d2, k):
                     setattr(d1, k, getattr(d2, k))
 
+        # This is the bare minimum to get pbr projects to show as having any
+        # sources.  I don't want to use pbr.util.cfg_to_args because it appears
+        # to import and run arbitrary code.
+        if d1.pbr:
+            where = "."
+            if d1.pbr__files__packages_root:
+                d1.package_dir = {"": d1.pbr__files__packages_root}
+                where = d1.pbr__files__packages_root
+
+            if d1.pbr__files__packages:
+                d1.packages = d1.pbr__files__packages
+            else:
+                d1.packages = FindPackages(where, (), ("*",))  # type: ignore
+
         # package_dir can both add and remove components, see docs
         # https://docs.python.org/2/distutils/setupscript.html#listing-whole-packages
         package_dir: Mapping[str, str] = d1.package_dir

--- a/dowsing/setuptools/__init__.py
+++ b/dowsing/setuptools/__init__.py
@@ -46,7 +46,7 @@ class SetuptoolsReader(BaseReader):
         # This is the bare minimum to get pbr projects to show as having any
         # sources.  I don't want to use pbr.util.cfg_to_args because it appears
         # to import and run arbitrary code.
-        if d1.pbr:
+        if d1.pbr or (d1.pbr__files__packages and not d1.packages):
             where = "."
             if d1.pbr__files__packages_root:
                 d1.package_dir = {"": d1.pbr__files__packages_root}

--- a/dowsing/setuptools/setup_and_metadata.py
+++ b/dowsing/setuptools/setup_and_metadata.py
@@ -222,4 +222,15 @@ SETUP_ARGS = [
         SetupCfg("options.packages.find", "include", writer_cls=ListCommaWriter),
         sample_value=None,
     ),
+    ConfigField("pbr", SetupCfg("--unused--", "--unused--"), sample_value=None,),
+    ConfigField(
+        "pbr__files__packages_root",
+        SetupCfg("files", "packages_root"),
+        sample_value=None,
+    ),
+    ConfigField(
+        "pbr__files__packages",
+        SetupCfg("files", "packages", writer_cls=ListCommaWriter),
+        sample_value=None,
+    ),
 ]

--- a/dowsing/tests/setuptools.py
+++ b/dowsing/tests/setuptools.py
@@ -303,3 +303,31 @@ packages_root = src
                 "pkg/tests/__init__.py": "src/pkg/tests/__init__.py",
             },
         )
+
+    def test_pbr_improperly_enabled(self) -> None:
+        # pbr itself is something like this.
+        d = self._read(
+            """\
+from setuptools import setup
+
+setup()""",
+            extra_files={
+                "setup.cfg": """\
+[metadata]
+name = pbr
+author = OpenStack Foundation
+
+[files]
+packages =
+    pkg
+"""
+            },
+        )
+        self.assertEqual(
+            d.source_mapping,
+            {
+                "pkg/__init__.py": "pkg/__init__.py",
+                "pkg/sub/__init__.py": "pkg/sub/__init__.py",
+                "pkg/tests/__init__.py": "pkg/tests/__init__.py",
+            },
+        )

--- a/dowsing/tests/setuptools.py
+++ b/dowsing/tests/setuptools.py
@@ -1,5 +1,6 @@
 import unittest
 from pathlib import Path
+from typing import Dict, Optional
 
 import volatile
 
@@ -63,10 +64,18 @@ setup(name=the_name, install_requires=["abc"], setup_requires=["def"])
                 ("setuptools", "wheel", "def"), r.get_requires_for_build_wheel()
             )
 
-    def _read(self, data: str, src_dir: str = ".") -> Distribution:
+    def _read(
+        self,
+        data: str,
+        src_dir: str = ".",
+        extra_files: Optional[Dict[str, str]] = None,
+    ) -> Distribution:
         with volatile.dir() as d:
             sp = Path(d, "setup.py")
             sp.write_text(data)
+            if extra_files:
+                for k, v in extra_files.items():
+                    Path(d, k).write_text(v)
             Path(d, src_dir, "pkg").mkdir(parents=True)
             Path(d, src_dir, "pkg", "__init__.py").touch()
             Path(d, src_dir, "pkg", "sub").mkdir()
@@ -232,3 +241,65 @@ setup(
         )
         # TODO wish this were None
         self.assertEqual(d.source_mapping, {})
+
+    def test_pbr_properly_enabled(self) -> None:
+        d = self._read(
+            """\
+from setuptools import setup
+
+setup(
+    setup_requires=['pbr>=1.9', 'setuptools>=17.1'],
+    pbr=True,
+)""",
+            extra_files={
+                "setup.cfg": """\
+[metadata]
+name = pbr
+author = OpenStack Foundation
+
+[files]
+packages =
+    pkg
+"""
+            },
+        )
+        self.assertEqual(
+            d.source_mapping,
+            {
+                "pkg/__init__.py": "pkg/__init__.py",
+                "pkg/sub/__init__.py": "pkg/sub/__init__.py",
+                "pkg/tests/__init__.py": "pkg/tests/__init__.py",
+            },
+        )
+
+    def test_pbr_properly_enabled_src(self) -> None:
+        d = self._read(
+            """\
+from setuptools import setup
+
+setup(
+    setup_requires=['pbr>=1.9', 'setuptools>=17.1'],
+    pbr=True,
+)""",
+            src_dir="src",
+            extra_files={
+                "setup.cfg": """\
+[metadata]
+name = pbr
+author = OpenStack Foundation
+
+[files]
+packages =
+    pkg
+packages_root = src
+"""
+            },
+        )
+        self.assertEqual(
+            d.source_mapping,
+            {
+                "pkg/__init__.py": "src/pkg/__init__.py",
+                "pkg/sub/__init__.py": "src/pkg/sub/__init__.py",
+                "pkg/tests/__init__.py": "src/pkg/tests/__init__.py",
+            },
+        )

--- a/dowsing/types.py
+++ b/dowsing/types.py
@@ -60,6 +60,9 @@ class Distribution(pkginfo.distribution.Distribution):  # type: ignore
     find_packages_exclude: Sequence[str] = ()
     find_packages_include: Sequence[str] = ("*",)
     source_mapping: Optional[Mapping[str, str]] = None
+    pbr: Optional[bool] = None
+    pbr__files__packages_root: Optional[str] = None
+    pbr__files__packages: Optional[str] = None
 
     def _getHeaderAttrs(self) -> Sequence[Tuple[str, str, bool]]:
         # Until I invent a metadata version to include this, do so
@@ -80,6 +83,9 @@ class Distribution(pkginfo.distribution.Distribution):  # type: ignore
             ("X-Packages-Dict", "packages_dict", False),
             ("X-Py-Modules", "py_modules", True),
             ("X-Entry-Points", "entry_points", False),
+            ("X-Pbr", "pbr", False),
+            ("X-pbr__files__packages_root", "pbr__files__packages_root", False),
+            ("X-pbr__files__packages", "pbr__files__packages", True),
         )
 
     def asdict(self) -> Dict[str, Any]:


### PR DESCRIPTION
Refs #7

Out of ~168 popular projects using pbr in some way, 4 work ok now.  cssutils only uses it for tests, retry includes a (redundant) call to find_packages.

After this PR, 127 work ok, and many of the remaining ones are either `.data` (#13), namespace packages (#15), including extra dirs like `tests` or `examples` (#17), or broken sdists (#16).

Test with `python -m dowsing.check_source_mapping <projectname>` and it will give a summary of differences.