### PR TITLE
Enhanced package compatibility

### DIFF
--- a/dowsing/setuptools/__init__.py
+++ b/dowsing/setuptools/__init__.py
@@ -96,8 +96,10 @@ class SetuptoolsReader(BaseReader):
                     d1.find_packages_include,
                 ):
                     d1.packages_dict[p] = mangle(p)
-            elif d1.packages != "??":
-                assert isinstance(d1.packages, (list, tuple))
+            elif d1.packages not in ("??", "????"):
+                assert isinstance(
+                    d1.packages, (list, tuple)
+                ), f"{d1.packages!r} is not a list/tuple"
                 for p in d1.packages:
                     if p:
                         d1.packages_dict[p] = mangle(p)

--- a/dowsing/types.py
+++ b/dowsing/types.py
@@ -63,6 +63,7 @@ class Distribution(pkginfo.distribution.Distribution):  # type: ignore
     pbr: Optional[bool] = None
     pbr__files__packages_root: Optional[str] = None
     pbr__files__packages: Optional[str] = None
+    provides_extra: Optional[Sequence[str]] = ()
 
     def _getHeaderAttrs(self) -> Sequence[Tuple[str, str, bool]]:
         # Until I invent a metadata version to include this, do so


### PR DESCRIPTION
Adds support for parsing *something* from fastai/fastprogress, dirsync, and plotly, even if it doesn't understand everything. 

```
(.venv) jreese@butterfree ~/workspace/dowsing enhance  » python -m dowsing.pep517 ~/workspace/dirsync | jq
/Users/jreese/.pyenv/versions/3.9.3/lib/python3.9/runpy.py:127: RuntimeWarning: 'dowsing.pep517' found in sys.modules after import of package 'dowsing', but prior to execution of 'dowsing.pep517'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
{
  "get_requires_for_build_sdist": [
    "setuptools"
  ],
  "get_requires_for_build_wheel": [
    "setuptools",
    "wheel"
  ],
  "get_metadata": {
    "metadata_version": "2.1",
    "summary": "Advanced directory tree synchronisation tool",
    "description": "??",
    "keywords": [
      "directory",
      "folder",
      "update",
      "synchronisation"
    ],
    "home_page": "https://github.com/tkhyn/dirsync/",
    "author": "Thomas Khyn",
    "author_email": "thomas@ksytek.com",
    "classifiers": [
      "Programming Language :: Python",
      "Programming Language :: Python :: 2",
      "Programming Language :: Python :: 3",
      "License :: OSI Approved :: MIT License",
      "Operating System :: OS Independent",
      "??",
      "Intended Audience :: Developers",
      "Intended Audience :: End Users/Desktop",
      "Environment :: Console",
      "Topic :: Utilities",
      "Topic :: Desktop Environment",
      "Topic :: System :: Archiving :: Backup",
      "Topic :: System :: Archiving :: Mirroring"
    ],
    "requires_dist": [
      "six"
    ],
    "packages": "FindPackages('.', (), ('*',)",
    "packages_dict": {
      "tests": "tests",
      "dirsync": "dirsync"
    },
    "entry_points": {
      "console_scripts": [
        "dirsync = dirsync.run:from_cmdline"
      ]
    }
  },
  "source_mapping": {
    "dirsync/syncer.py": "dirsync/syncer.py",
    "dirsync/options.py": "dirsync/options.py",
    "dirsync/run.py": "dirsync/run.py",
    "dirsync/version.py": "dirsync/version.py",
    "dirsync/__init__.py": "dirsync/__init__.py",
    "tests/update.py": "tests/update.py",
    "tests/sync.py": "tests/sync.py",
    "tests/_base.py": "tests/_base.py",
    "tests/base_tests.py": "tests/base_tests.py",
    "tests/regexfilters.py": "tests/regexfilters.py",
    "tests/cmdline.py": "tests/cmdline.py",
    "tests/__init__.py": "tests/__init__.py",
    "tests/diff.py": "tests/diff.py",
    "tests/setup.cfg": "tests/setup.cfg",
    "tests/_README.rst": "tests/_README.rst",
    "tests/errors.py": "tests/errors.py",
    "tests/trees.py": "tests/trees.py"
  }
}
```

```
(.venv) jreese@butterfree ~/workspace/dowsing enhance  ‹130› » python -m dowsing.pep517 ~/workspace/plotly.py/packages/python/plotly/ | jq
/Users/jreese/.pyenv/versions/3.9.3/lib/python3.9/runpy.py:127: RuntimeWarning: 'dowsing.pep517' found in sys.modules after import of package 'dowsing', but prior to execution of 'dowsing.pep517'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
{
  "get_requires_for_build_sdist": [
    "jupyterlab~=3.0;python_version>='3.6'",
    "setuptools>=40.8.0",
    "wheel",
    "setuptools"
  ],
  "get_requires_for_build_wheel": [
    "jupyterlab~=3.0;python_version>='3.6'",
    "setuptools>=40.8.0",
    "wheel",
    "setuptools",
    "wheel"
  ],
  "get_metadata": {
    "metadata_version": "2.1",
    "name": "plotly",
    "version": "??",
    "summary": "An open-source, interactive data visualization library for Python",
    "description": "??",
    "home_page": "https://plotly.com/python/",
    "author": "Chris P",
    "author_email": "chris@plot.ly",
    "license": "MIT",
    "classifiers": [
      "Development Status :: 5 - Production/Stable",
      "Programming Language :: Python :: 3.6",
      "Programming Language :: Python :: 3.7",
      "Programming Language :: Python :: 3.8",
      "Programming Language :: Python :: 3.9",
      "Topic :: Scientific/Engineering :: Visualization"
    ],
    "maintainer": "Nicolas Kruchten",
    "maintainer_email": "nicolas@plot.ly",
    "requires_python": ">=3.6",
    "requires_dist": [
      "tenacity>=6.2.0",
      "six"
    ],
    "project_urls": {
      "Github": "https://github.com/plotly/plotly.py"
    },
    "description_content_type": "text/markdown",
    "package_data": {
      "plotly": [
        "package_data/*",
        "package_data/templates/*",
        "package_data/datasets/*"
      ],
      "jupyterlab_plotly": [
        "nbextension/*",
        "labextension/*",
        "labextension/static/*"
      ]
    },
    "packages": "????"
  },
  "source_mapping": {}
}
```

```
(.venv) jreese@butterfree ~/workspace/dowsing enhance  ‹130› » python -m dowsing.pep517 ~/workspace/fastprogress | jq
/Users/jreese/.pyenv/versions/3.9.3/lib/python3.9/runpy.py:127: RuntimeWarning: 'dowsing.pep517' found in sys.modules after import of package 'dowsing', but prior to execution of 'dowsing.pep517'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
{
  "get_requires_for_build_sdist": [
    "setuptools"
  ],
  "get_requires_for_build_wheel": [
    "setuptools",
    "wheel"
  ],
  "get_metadata": {
    "metadata_version": "2.1",
    "name": "??",
    "description": "??",
    "home_page": "??",
    "license": "??",
    "classifiers": "??",
    "requires_python": ">=??",
    "requires_dist": "??",
    "description_content_type": "text/markdown",
    "include_package_data": true,
    "packages": "FindPackages('.', (), ('*',)",
    "packages_dict": {
      "fastprogress": "fastprogress"
    },
    "entry_points": {
      "console_scripts": "??"
    }
  },
  "source_mapping": {
    "fastprogress/fastprogress.py": "fastprogress/fastprogress.py",
    "fastprogress/version.py": "fastprogress/version.py",
    "fastprogress/_nbdev.py": "fastprogress/_nbdev.py",
    "fastprogress/__init__.py": "fastprogress/__init__.py",
    "fastprogress/core.py": "fastprogress/core.py"
  }
}
```