### PR TITLE
Try reading long_description from payload body

### DIFF
--- a/dowsing/tests/setuptools_metadata.py
+++ b/dowsing/tests/setuptools_metadata.py
@@ -96,6 +96,12 @@ class SetupArgsTest(unittest.TestCase):
                     a = setup_py_info.get_all(field.metadata.key)
                     b = setup_cfg_info.get_all(field.metadata.key)
 
+                    # setuptools>=57 writes long_description to the body/payload
+                    # of PKG-INFO, and skips the description field entirely.
+                    if field.keyword == "long_description" and a is None:
+                        a = setup_py_info.get_payload()
+                        b = setup_cfg_info.get_payload()
+
                     # install_requires gets written out to *.egg-info/requires.txt
                     # instead
                     if field.keyword != "install_requires":


### PR DESCRIPTION
Updates the test_arg_mapping case to handle setuptools >= 57,
which writes the long_description field as the payload/body of
PKG-INFO, skipping the previous `Description:` field entirely.
This results in the missing key from the Message object, so the
test then expects to read long_description from the payload.

Fixes #33 