### PR TITLE
Initial support for PEP 621 metadata with Flit

### DIFF
--- a/dowsing/pep621.py
+++ b/dowsing/pep621.py
@@ -1,0 +1,49 @@
+import tomlkit
+from setuptools import find_packages
+
+from .types import BaseReader, Distribution
+
+
+class Pep621Reader(BaseReader):
+    def get_pep621_metadata(self) -> Distribution:
+        pyproject = self.path / "pyproject.toml"
+        doc = tomlkit.parse(pyproject.read_text())
+
+        d = Distribution()
+        d.metadata_version = "2.1"
+        d.project_urls = {}
+        d.entry_points = {}
+        d.requires_dist = []
+        d.packages = []
+        d.packages_dict = {}
+
+        table = doc.get("project", None)
+        if table:
+            for k, v in table.items():
+                if k == "name":
+                    if (self.path / f"{v}.py").exists():
+                        d.py_modules = [v]
+                    else:
+                        d.packages = find_packages(
+                            self.path.as_posix(), include=(f"{v}.*")
+                        )
+                        d.packages_dict = {i: i.replace(".", "/") for i in d.packages}
+                elif k == "license":
+                    if "text" in v:
+                        v = v["text"]
+                    elif "file" in v:
+                        v = f"file: {v['file']}"
+                    else:
+                        raise ValueError("no known license field values")
+                elif k == "dependencies":
+                    k = "requires_dist"
+                elif k == "optional-dependencies":
+                    pass
+                elif k == "urls":
+                    d.project_urls.update(v)
+
+                k2 = k.replace("-", "_")
+                if k2 in d:
+                    setattr(d, k2, v)
+
+        return d

--- a/dowsing/tests/__init__.py
+++ b/dowsing/tests/__init__.py
@@ -2,6 +2,7 @@ from .api import ApiTest
 from .flit import FlitReaderTest
 from .maturin import MaturinReaderTest
 from .pep517 import Pep517Test
+from .pep621 import Pep621ReaderTest
 from .poetry import PoetryReaderTest
 from .setuptools import SetuptoolsReaderTest
 from .setuptools_metadata import SetupArgsTest
@@ -12,6 +13,7 @@ __all__ = [
     "FlitReaderTest",
     "MaturinReaderTest",
     "Pep517Test",
+    "Pep621ReaderTest",
     "PoetryReaderTest",
     "SetuptoolsReaderTest",
     "WriterTest",

--- a/dowsing/tests/flit.py
+++ b/dowsing/tests/flit.py
@@ -23,8 +23,8 @@ name = "Name"
             # handle missing metadata appropriately.
 
             r = FlitReader(dp)
-            self.assertEqual((), r.get_requires_for_build_sdist())
-            self.assertEqual((), r.get_requires_for_build_wheel())
+            self.assertEqual([], r.get_requires_for_build_sdist())
+            self.assertEqual([], r.get_requires_for_build_wheel())
             md = r.get_metadata()
             self.assertEqual("Name", md.name)
 
@@ -62,6 +62,47 @@ Foo = "https://"
                 {
                     "metadata_version": "2.1",
                     "name": "Name",
+                    "packages": ["foo", "foo.tests"],
+                    "packages_dict": {"foo": "foo", "foo.tests": "foo/tests"},
+                    "requires_dist": ["abc", "def"],
+                    "project_urls": {"Foo": "https://"},
+                },
+                md.asdict(),
+            )
+
+    def test_pep621(self) -> None:
+        with volatile.dir() as d:
+            dp = Path(d)
+            (dp / "pyproject.toml").write_text(
+                """\
+[build-system]
+requires = ["flit_core >=2,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "foo"
+dependencies = ["abc", "def"]
+
+[project.urls]
+Foo = "https://"
+"""
+            )
+            (dp / "foo").mkdir()
+            (dp / "foo" / "tests").mkdir()
+            (dp / "foo" / "__init__.py").write_text("")
+            (dp / "foo" / "tests" / "__init__.py").write_text("")
+
+            r = FlitReader(dp)
+            # Notably these do not include flit itself; that's handled by
+            # dowsing.pep517
+            self.assertEqual(["abc", "def"], r.get_requires_for_build_sdist())
+            self.assertEqual(["abc", "def"], r.get_requires_for_build_wheel())
+            md = r.get_metadata()
+            self.assertEqual("foo", md.name)
+            self.assertEqual(
+                {
+                    "metadata_version": "2.1",
+                    "name": "foo",
                     "packages": ["foo", "foo.tests"],
                     "packages_dict": {"foo": "foo", "foo.tests": "foo/tests"},
                     "requires_dist": ["abc", "def"],

--- a/dowsing/tests/pep621.py
+++ b/dowsing/tests/pep621.py
@@ -1,0 +1,57 @@
+import unittest
+from pathlib import Path
+
+import volatile
+
+from ..pep621 import Pep621Reader
+
+
+class Pep621ReaderTest(unittest.TestCase):
+    def test_simplest(self) -> None:
+        with volatile.dir() as d:
+            dp = Path(d)
+            (dp / "pyproject.toml").write_text(
+                """\
+[project]
+name = "Name"
+"""
+            )
+
+            r = Pep621Reader(dp)
+            md = r.get_pep621_metadata()
+            self.assertEqual("Name", md.name)
+
+    def test_normal(self) -> None:
+        with volatile.dir() as d:
+            dp = Path(d)
+            (dp / "pyproject.toml").write_text(
+                """\
+[project]
+name = "foo"
+dependencies = ["abc", "def"]
+license = {text = "MIT"}
+
+[project.urls]
+Foo = "https://"
+"""
+            )
+            (dp / "foo").mkdir()
+            (dp / "foo" / "tests").mkdir()
+            (dp / "foo" / "__init__.py").write_text("")
+            (dp / "foo" / "tests" / "__init__.py").write_text("")
+
+            r = Pep621Reader(dp)
+            md = r.get_pep621_metadata()
+            self.assertEqual("foo", md.name)
+            self.assertEqual(
+                {
+                    "metadata_version": "2.1",
+                    "name": "foo",
+                    "license": "MIT",
+                    "packages": ["foo", "foo.tests"],
+                    "packages_dict": {"foo": "foo", "foo.tests": "foo/tests"},
+                    "requires_dist": ["abc", "def"],
+                    "project_urls": {"Foo": "https://"},
+                },
+                md.asdict(),
+            )


### PR DESCRIPTION
This adds a `Pep621Reader` class that pulls metadata from the [project]
table of pyproject.toml. The `FlitReader` class uses this as a basis
for reading metadata, and is also updated to not fail if the flit table
is missing.
