### PR TITLE
explicitly use python3 for makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON?=python
+PYTHON?=python3
 SOURCES=dowsing setup.py
 
 .PHONY: venv


### PR DESCRIPTION
Running `make venv` on a mac doesn't work as expected since it's still aliased to `python2`

```
(dowsing-dev) bgerrity@bgerrity-mbp dowsing % make venv
python -m venv .venv
/System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python: No module named venv
make: *** [venv] Error 1
```