### PR TITLE
More robust evaluation of assignments

### DIFF
--- a/dowsing/tests/setuptools.py
+++ b/dowsing/tests/setuptools.py
@@ -373,3 +373,23 @@ setup(
         self.assertEqual(d.name, "foobar")
         self.assertEqual(d.version, "base.suffix")
         self.assertListEqual(d.classifiers, ["123", "abc", "xyz"])
+
+    def test_circular_references(self) -> None:
+        d = self._read(
+            """\
+from setuptools import setup
+
+name = "foo"
+
+foo = bar
+bar = version
+version = foo
+
+setup(
+    name=name,
+    version=version,
+)
+            """
+        )
+        self.assertEqual(d.name, "foo")
+        self.assertEqual(d.version, "??")

--- a/dowsing/tests/setuptools.py
+++ b/dowsing/tests/setuptools.py
@@ -385,6 +385,8 @@ foo = bar
 bar = version
 version = foo
 
+classifiers = classifiers
+
 setup(
     name=name,
     version=version,
@@ -393,3 +395,4 @@ setup(
         )
         self.assertEqual(d.name, "foo")
         self.assertEqual(d.version, "??")
+        self.assertEqual(d.classifiers, ())

--- a/dowsing/tests/setuptools.py
+++ b/dowsing/tests/setuptools.py
@@ -372,7 +372,7 @@ setup(
         )
         self.assertEqual(d.name, "foobar")
         self.assertEqual(d.version, "base.suffix")
-        self.assertListEqual(d.classifiers, ["123", "abc", "xyz"])
+        self.assertSequenceEqual(d.classifiers, ["123", "abc", "xyz"])
 
     def test_circular_references(self) -> None:
         d = self._read(

--- a/dowsing/tests/setuptools.py
+++ b/dowsing/tests/setuptools.py
@@ -344,3 +344,32 @@ setup(name = a + "1111", packages=[] + p, classifiers=a + p)
         self.assertEqual(d.name, "aaaa1111")
         self.assertEqual(d.packages, ["a", "b", "c"])
         self.assertEqual(d.classifiers, "??")
+
+    def test_self_reference_assignments(self) -> None:
+        d = self._read(
+            """\
+from setuptools import setup
+
+version = "base"
+name = "foo"
+name += "bar"
+version = version + ".suffix"
+
+classifiers = [
+    "123",
+    "abc",
+]
+
+if True:
+    classifiers = classifiers + ["xyz"]
+
+setup(
+    name=name,
+    version=version,
+    classifiers=classifiers,
+)
+            """
+        )
+        self.assertEqual(d.name, "foobar")
+        self.assertEqual(d.version, "base.suffix")
+        self.assertListEqual(d.classifiers, ["123", "abc", "xyz"])

--- a/dowsing/tests/setuptools.py
+++ b/dowsing/tests/setuptools.py
@@ -396,3 +396,24 @@ setup(
         self.assertEqual(d.name, "foo")
         self.assertEqual(d.version, "??")
         self.assertEqual(d.classifiers, ())
+
+    def test_redefines_builtin(self) -> None:
+        d = self._read(
+            """\
+import setuptools
+with open("CREDITS.txt", "r", encoding="utf-8") as fp:
+    credits = fp.read()
+
+long_desc = "a" + credits + "b"
+name = "foo"
+
+kwargs = dict(
+    long_description = long_desc,
+    name = name,
+)
+
+setuptools.setup(**kwargs)
+"""
+        )
+        self.assertEqual(d.name, "foo")
+        self.assertEqual(d.description, "??")


### PR DESCRIPTION
Improves assignment evaluation in a number of ways:
- Evaluates assignments in reverse line-number order, from bottom to top
- Tracks target name and line number when evaluating recursively
- Only considers recursive assignments that occur before the current target line
- Attempts evaluating earlier assignments if later assignments are inconclusive
- Prevent evaluating binary operands if either side evaluates to `"??"`
- Add support for "augmented assignments" like `+=`

This enables support for evaluating self-referential assignments like:

    foo = foo + bar

or

    foo += bar

Adds a basic test covering both self-referential assignment types.

Fixes #56